### PR TITLE
Add pagination and filtering to email log

### DIFF
--- a/src/Controller/EmailLogController.php
+++ b/src/Controller/EmailLogController.php
@@ -3,7 +3,7 @@
  * EmailLogController.php
  * 
  * Controller für das Versandprotokoll (Userstory 20).
- * Zeigt die letzten 100 versendeten E-Mails und ermöglicht die Suche nach Ticket-ID.
+ * Zeigt versendete E-Mails mit Paginierung und ermöglicht die Suche nach Ticket-ID.
  */
 
 namespace App\Controller;
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use App\Repository\EmailSentRepository;
+use App\Service\PaginationService;
 
 class EmailLogController extends AbstractController
 {
@@ -24,22 +25,33 @@ class EmailLogController extends AbstractController
     }
 
     #[Route('/versandprotokoll', name: 'email_log')]
-    public function index(Request $request): Response
+    public function index(Request $request, PaginationService $paginationService): Response
     {
         $search = $request->query->get('search');
+        $filter = $request->query->get('filter', 'all');
+        $page = max(1, (int) $request->query->get('page', 1));
+
+        $queryBuilder = $this->emailSentRepository->createFilteredQueryBuilder($filter);
+
         if ($search) {
-            $emails = $this->emailSentRepository->createQueryBuilder('e')
-                ->where('e.ticketId LIKE :search')
-                ->setParameter('search', $search.'%')
-                ->orderBy('e.timestamp', 'DESC')
-                ->getQuery()
-                ->getResult();
+            $queryBuilder
+                ->andWhere('e.ticketId LIKE :search')
+                ->setParameter('search', $search . '%');
+
+            $emails = $queryBuilder->getQuery()->getResult();
+            $pagination = null;
         } else {
-            $emails = $this->emailSentRepository->findBy([], ['timestamp' => 'DESC'], 100);
+            $pagination = $paginationService->paginate($queryBuilder, $page, 50);
+            $emails = $pagination->results;
         }
+
         return $this->render('email_log/index.html.twig', [
             'emails' => $emails,
             'search' => $search,
+            'filter' => $filter,
+            'pagination' => $pagination,
+            'currentPage' => $pagination ? $pagination->currentPage : 1,
+            'totalPages' => $pagination ? $pagination->totalPages : 1,
         ]);
     }
 }

--- a/src/Repository/EmailSentRepository.php
+++ b/src/Repository/EmailSentRepository.php
@@ -33,6 +33,30 @@ class EmailSentRepository extends ServiceEntityRepository
     }
 
     /**
+     * Erstellt einen QueryBuilder für das Versandprotokoll mit optionaler Filterung
+     *
+     * Mit diesem QueryBuilder können E-Mails nach Test- oder Live-Modus gefiltert
+     * werden. Die Ergebnisse werden standardmäßig nach Zeitstempel absteigend
+     * sortiert, sodass die neuesten Einträge zuerst erscheinen.
+     *
+     * @param string $filter Filteroption ('all', 'live' oder 'test')
+     * @return \Doctrine\ORM\QueryBuilder Der konfigurierte QueryBuilder
+     */
+    public function createFilteredQueryBuilder(string $filter = 'all'): \Doctrine\ORM\QueryBuilder
+    {
+        $qb = $this->createQueryBuilder('e')
+            ->orderBy('e.timestamp', 'DESC');
+
+        if ($filter === 'live') {
+            $qb->andWhere('e.testMode = false');
+        } elseif ($filter === 'test') {
+            $qb->andWhere('e.testMode = true');
+        }
+
+        return $qb;
+    }
+
+    /**
      * Findet die zuletzt gesendeten E-Mails
      * 
      * Diese Methode ruft die neuesten E-Mail-Protokolle ab, sortiert nach

--- a/templates/email_log/index.html.twig
+++ b/templates/email_log/index.html.twig
@@ -5,10 +5,31 @@
 {% block body %}
     <h1 class="mb-4">Versandprotokoll</h1>
     <form method="get" class="mb-3">
-        <div class="input-group">
-            <input type="text" name="search" class="form-control" placeholder="Ticket-ID suchen..." value="{{ search|default('') }}">
-            <button class="btn btn-primary" type="submit">Suchen</button>
+        <div class="row g-2 align-items-end">
+            <div class="col-md-6">
+                <div class="input-group">
+                    <input type="text" name="search" class="form-control" placeholder="Ticket-ID suchen..." value="{{ search|default('') }}">
+                    <button class="btn btn-primary" type="submit">Suchen</button>
+                </div>
+            </div>
+            <div class="col-md-6 text-md-end mt-2 mt-md-0">
+                <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" name="filter" id="filter_all" value="all" {{ filter == 'all' ? 'checked' }} onchange="this.form.submit()">
+                    <label class="form-check-label" for="filter_all">Alle E-Mails anzeigen</label>
+                </div>
+                <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" name="filter" id="filter_live" value="live" {{ filter == 'live' ? 'checked' }} onchange="this.form.submit()">
+                    <label class="form-check-label" for="filter_live">Nur Live-Mails anzeigen</label>
+                </div>
+                <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="radio" name="filter" id="filter_test" value="test" {{ filter == 'test' ? 'checked' }} onchange="this.form.submit()">
+                    <label class="form-check-label" for="filter_test">Nur Test-Mails anzeigen</label>
+                </div>
+            </div>
         </div>
+        {% if search is empty %}
+            <input type="hidden" name="page" value="{{ currentPage }}">
+        {% endif %}
     </form>
     {% if emails is empty %}
         <div class="alert alert-info">Keine E-Mails gefunden.</div>
@@ -53,5 +74,24 @@
                 </tbody>
             </table>
         </div>
+        {% if pagination is not null %}
+            <div class="d-flex justify-content-between align-items-center mt-3">
+                <div class="text-muted">
+                    Seite {{ currentPage }} von {{ totalPages }}
+                </div>
+                <div class="btn-group" role="group">
+                    {% if pagination.hasPrevious %}
+                        <a href="{{ path('email_log', {'page': pagination.getPreviousPage(), 'filter': filter}) }}" class="btn btn-outline-primary">Zurück</a>
+                    {% else %}
+                        <span class="btn btn-outline-secondary disabled">Zurück</span>
+                    {% endif %}
+                    {% if pagination.hasNext %}
+                        <a href="{{ path('email_log', {'page': pagination.getNextPage(), 'filter': filter}) }}" class="btn btn-outline-primary">Weiter</a>
+                    {% else %}
+                        <span class="btn btn-outline-secondary disabled">Weiter</span>
+                    {% endif %}
+                </div>
+            </div>
+        {% endif %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- implement filtered query builder in `EmailSentRepository`
- paginate email log and handle filter/search in `EmailLogController`
- enhance email log template with filter radio buttons and navigation

## Testing
- `./run_all_tests.sh --quick` *(fails: database connection)*

------
https://chatgpt.com/codex/tasks/task_e_687dfff34e0c833190975c85368ea33b