### PR TITLE
Add PHPUnit tests, static analysis, and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+      - uses: ramsey/composer-install@v2
+        with:
+          composer-options: --no-interaction --no-progress
+      - run: vendor/bin/phpunit
+      - run: vendor/bin/phpstan analyse --no-progress
+      - run: vendor/bin/psalm --no-progress

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,10 @@
         "symfony/debug-bundle": "^6.4",
         "symfony/maker-bundle": "^1.48",
         "symfony/stopwatch": "^6.4",
-        "symfony/web-profiler-bundle": "^6.4"
+        "symfony/web-profiler-bundle": "^6.4",
+        "phpunit/phpunit": "^10.5",
+        "phpstan/phpstan": "^1.11",
+        "vimeo/psalm": "^5.26"
     },
     "config": {
         "allow-plugins": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: 8
+    paths:
+        - src
+    tmpDir: var/cache/phpstan

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<psalm xmlns="https://getpsalm.org/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" errorLevel="1" phpVersion="8.3">
+    <projectFiles>
+        <directory name="src"/>
+    </projectFiles>
+</psalm>

--- a/tests/Integration/CsvProcessorTest.php
+++ b/tests/Integration/CsvProcessorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Tests\Integration;
+
+use App\Service\CsvFileReader;
+use App\Service\CsvProcessor;
+use App\Service\UserValidator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+class DummyUserValidator extends UserValidator
+{
+    private array $known;
+
+    public function __construct(array $known)
+    {
+        $this->known = array_flip($known);
+    }
+
+    public function identifyUnknownUsers(array $usernames): array
+    {
+        $unknown = [];
+        foreach (array_keys($usernames) as $username) {
+            if (!isset($this->known[$username])) {
+                $unknown[] = $username;
+            }
+        }
+        return $unknown;
+    }
+}
+
+class CsvProcessorTest extends TestCase
+{
+    public function testProcessCsvFile(): void
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $request = new Request();
+        $request->setSession($session);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $csvFileReader = new CsvFileReader();
+        $userValidator = new DummyUserValidator(['known1', 'known2']);
+        $processor = new CsvProcessor($csvFileReader, $userValidator, $requestStack);
+
+        $filePath = __DIR__ . '/../fixtures/tickets.csv';
+        $uploaded = new UploadedFile($filePath, 'tickets.csv', 'text/csv', null, true);
+
+        $result = $processor->process($uploaded);
+
+        $this->assertCount(3, $result['validTickets']);
+        $this->assertCount(1, $result['invalidRows']);
+        $this->assertSame(['unknown1'], $result['unknownUsers']);
+        $this->assertSame($result['validTickets'], $session->get('valid_tickets'));
+    }
+}

--- a/tests/Service/UserValidatorTest.php
+++ b/tests/Service/UserValidatorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Service\UserValidator;
+use PHPUnit\Framework\TestCase;
+
+class InMemoryUserRepository extends UserRepository
+{
+    /** @var array<int,User> */
+    private array $users;
+
+    public function __construct(array $users)
+    {
+        $this->users = $users;
+    }
+
+    public function findMultipleByUsernames(array $usernames): array
+    {
+        return array_values(array_filter(
+            $this->users,
+            fn(User $u) => in_array($u->getUsername(), $usernames, true)
+        ));
+    }
+
+    public function findOneByUsername(string $username): ?User
+    {
+        foreach ($this->users as $user) {
+            if ($user->getUsername() === $username) {
+                return $user;
+            }
+        }
+        return null;
+    }
+}
+
+class UserValidatorTest extends TestCase
+{
+    public function testIdentifyUnknownUsers(): void
+    {
+        $known = (new User())->setUsername('known1')->setEmail('k@example.com');
+        $repo = new InMemoryUserRepository([$known]);
+        $validator = new UserValidator($repo);
+
+        $unknown = $validator->identifyUnknownUsers(['known1' => true, 'unknown1' => true]);
+
+        $this->assertSame(['unknown1'], $unknown);
+    }
+
+    public function testIsKnownUser(): void
+    {
+        $known = (new User())->setUsername('known1')->setEmail('k@example.com');
+        $repo = new InMemoryUserRepository([$known]);
+        $validator = new UserValidator($repo);
+
+        $this->assertTrue($validator->isKnownUser('known1'));
+        $this->assertFalse($validator->isKnownUser('unknown1'));
+    }
+}

--- a/tests/fixtures/tickets.csv
+++ b/tests/fixtures/tickets.csv
@@ -1,0 +1,5 @@
+ticketId,username,ticketName
+1,known1,Ticket A
+2,known2,Ticket B
+3,,Ticket C
+4,unknown1,


### PR DESCRIPTION
## Summary
- add phpunit, phpstan, and psalm dev dependencies
- configure phpstan, psalm, and phpunit
- create unit test for UserValidator and integration test for CsvProcessor
- set up GitHub Actions workflow for tests and static analysis

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `vendor/bin/phpstan --version` *(fails: No such file or directory)*
- `vendor/bin/psalm --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a059b89148833190f1fcd94af3324a