### PR TITLE
Add unit tests for AdminPassword entity

### DIFF
--- a/tests/Entity/AdminPasswordTest.php
+++ b/tests/Entity/AdminPasswordTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\AdminPassword;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Validation;
+
+class AdminPasswordTest extends TestCase
+{
+    public function testGettersAndSetters(): void
+    {
+        $adminPassword = new AdminPassword();
+
+        $adminPassword->setPassword('hashed');
+        $adminPassword->setPlainPassword('plain1234');
+
+        $this->assertSame('hashed', $adminPassword->getPassword());
+        $this->assertSame('plain1234', $adminPassword->getPlainPassword());
+    }
+
+    public function testPlainPasswordCannotBeBlank(): void
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+
+        $adminPassword = new AdminPassword();
+        $adminPassword->setPlainPassword('');
+
+        $violations = $validator->validate($adminPassword);
+
+        $this->assertGreaterThan(0, $violations->count());
+        $this->assertSame('Das Passwort darf nicht leer sein', $violations[0]->getMessage());
+    }
+
+    public function testPlainPasswordMustHaveMinimumLength(): void
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+
+        $adminPassword = new AdminPassword();
+        $adminPassword->setPlainPassword('short');
+
+        $violations = $validator->validate($adminPassword);
+
+        $this->assertGreaterThan(0, $violations->count());
+        $this->assertSame('Das Passwort muss mindestens 8 Zeichen enthalten', $violations[0]->getMessage());
+    }
+
+    public function testPlainPasswordValid(): void
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+
+        $adminPassword = new AdminPassword();
+        $adminPassword->setPlainPassword('longenough');
+
+        $violations = $validator->validate($adminPassword);
+
+        $this->assertCount(0, $violations);
+    }
+}


### PR DESCRIPTION
## Summary
- add AdminPassword entity tests for getters, setters, and validation rules

## Testing
- `vendor/bin/phpunit tests/Entity/AdminPasswordTest.php` *(fails: No such file or directory)*
- `composer install` *(fails: curl error 56 while downloading symfony/polyfill-mbstring: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a587164e2c8331a7094345fd5217d8