### PR TITLE
Add EmailSkippedEvent and update EmailStatus for skip detection

### DIFF
--- a/src/Event/Email/EmailSkippedEvent.php
+++ b/src/Event/Email/EmailSkippedEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Event\Email;
+
+use App\Event\AbstractDomainEvent;
+use App\ValueObject\TicketId;
+use App\ValueObject\Username;
+use App\ValueObject\EmailAddress;
+use App\ValueObject\EmailStatus;
+
+/**
+ * Event: Eine E-Mail wurde übersprungen
+ * 
+ * Wird ausgelöst, wenn eine Ticket-E-Mail nicht versendet wurde, weil:
+ * - Das Ticket bereits verarbeitet wurde
+ * - Es sich um ein Duplikat in der CSV handelt
+ * - Der Benutzer von Umfragen ausgeschlossen ist
+ * - Kein Benutzer/E-Mail gefunden wurde
+ * 
+ * Ermöglicht Audit-Logging, Statistiken und Follow-up-Aktionen.
+ */
+class EmailSkippedEvent extends AbstractDomainEvent
+{
+    public function __construct(
+        public readonly TicketId $ticketId,
+        public readonly Username $username,
+        public readonly ?EmailAddress $email,
+        public readonly EmailStatus $status,
+        public readonly bool $testMode = false,
+        public readonly ?string $ticketName = null
+    ) {
+        parent::__construct();
+    }
+}

--- a/src/Service/EmailService.php
+++ b/src/Service/EmailService.php
@@ -20,6 +20,7 @@ use App\Repository\UserRepository;
 use App\Repository\EmailSentRepository;
 use App\Event\Email\EmailSentEvent;
 use App\Event\Email\EmailFailedEvent;
+use App\Event\Email\EmailSkippedEvent;
 use App\Event\Email\BulkEmailCompletedEvent;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -162,6 +163,16 @@ class EmailService
                     $this->entityManager->persist($emailRecord);
                     $this->entityManager->flush();
                     $sentEmails[] = $emailRecord;
+                    
+                    // 🔥 EVENT: E-Mail übersprungen (Duplikat in CSV)
+                    $this->eventDispatcher->dispatch(new EmailSkippedEvent(
+                        $emailRecord->getTicketId(),
+                        $emailRecord->getUsername(),
+                        $emailRecord->getEmail(),
+                        $emailRecord->getStatus(),
+                        $emailRecord->getTestMode(),
+                        $emailRecord->getTicketName()
+                    ));
                 } catch (\Exception $e) {
                     error_log('Error saving duplicate record for ticket ' . $ticketId . ': ' . $e->getMessage());
                 }
@@ -181,6 +192,16 @@ class EmailService
                     $this->entityManager->persist($emailRecord);
                     $this->entityManager->flush();
                     $sentEmails[] = $emailRecord;
+                    
+                    // 🔥 EVENT: E-Mail übersprungen (bereits verarbeitet)
+                    $this->eventDispatcher->dispatch(new EmailSkippedEvent(
+                        $emailRecord->getTicketId(),
+                        $emailRecord->getUsername(),
+                        $emailRecord->getEmail(),
+                        $emailRecord->getStatus(),
+                        $emailRecord->getTestMode(),
+                        $emailRecord->getTicketName()
+                    ));
                 } catch (\Exception $e) {
                     error_log('Error saving existing ticket record for ticket ' . $ticketId . ': ' . $e->getMessage());
                 }
@@ -201,6 +222,16 @@ class EmailService
                     $this->entityManager->persist($emailRecord);
                     $this->entityManager->flush();
                     $sentEmails[] = $emailRecord;
+                    
+                    // 🔥 EVENT: E-Mail übersprungen (Benutzer ausgeschlossen)
+                    $this->eventDispatcher->dispatch(new EmailSkippedEvent(
+                        $emailRecord->getTicketId(),
+                        $emailRecord->getUsername(),
+                        $emailRecord->getEmail(),
+                        $emailRecord->getStatus(),
+                        $emailRecord->getTestMode(),
+                        $emailRecord->getTicketName()
+                    ));
                 } catch (\Exception $e) {
                     error_log('Error saving excluded user record for ticket ' . $ticketId . ': ' . $e->getMessage());
                 }
@@ -335,6 +366,17 @@ class EmailService
             $emailRecord->setEmail(null);
             $emailRecord->setSubject('');
             $emailRecord->setStatus(EmailStatus::error('no email found'));
+            
+            // 🔥 EVENT: E-Mail übersprungen (kein Benutzer gefunden)
+            $this->eventDispatcher->dispatch(new EmailSkippedEvent(
+                $emailRecord->getTicketId(),
+                $emailRecord->getUsername(),
+                $emailRecord->getEmail(),
+                $emailRecord->getStatus(),
+                $emailRecord->getTestMode(),
+                $emailRecord->getTicketName()
+            ));
+            
             return $emailRecord;
         }
         

--- a/src/ValueObject/EmailStatus.php
+++ b/src/ValueObject/EmailStatus.php
@@ -199,4 +199,17 @@ final class EmailStatus
     {
         return str_starts_with($this->value, 'Nicht versendet – Von Umfragen ausgeschlossen');
     }
+
+    /**
+     * Prüft, ob der Status anzeigt, dass die E-Mail übersprungen wurde (alle Skip-Szenarien)
+     * 
+     * @return bool True, wenn die E-Mail aus irgendeinem Grund übersprungen wurde
+     */
+    public function isSkipped(): bool
+    {
+        return $this->isAlreadyProcessed() 
+            || $this->isDuplicate() 
+            || $this->isExcludedFromSurvey()
+            || str_starts_with($this->value, 'Nicht versendet');
+    }
 }

--- a/src/ValueObject/EmailStatus.php
+++ b/src/ValueObject/EmailStatus.php
@@ -209,7 +209,6 @@ final class EmailStatus
     {
         return $this->isAlreadyProcessed() 
             || $this->isDuplicate() 
-            || $this->isExcludedFromSurvey()
-            || str_starts_with($this->value, 'Nicht versendet');
+            || $this->isExcludedFromSurvey();
     }
 }

--- a/templates/csv_upload/send_result.html.twig
+++ b/templates/csv_upload/send_result.html.twig
@@ -23,11 +23,11 @@
             {% set errorCount = 0 %}
             {% set skippedCount = 0 %}
             {% for email in sentEmails %}
-                {% if email.status starts with 'error' %}
+                {% if email.status.isError %}
                     {% set errorCount = errorCount + 1 %}
-                {% elseif email.status starts with 'Nicht versendet' %}
+                {% elseif email.status.isSkipped %}
                     {% set skippedCount = skippedCount + 1 %}
-                {% else %}
+                {% elseif email.status.isSent %}
                     {% set successCount = successCount + 1 %}
                 {% endif %}
             {% endfor %}
@@ -92,12 +92,14 @@
                                 <td>{{ email.ticketName }}</td>
                                 <td>{{ email.username }}</td>
                                 <td>{{ email.email }}</td>                                <td>
-                                    {% if email.status starts with 'error' %}
+                                    {% if email.status.isError %}
                                         <span class="badge bg-danger">{{ email.status }}</span>
-                                    {% elseif email.status starts with 'Nicht versendet' %}
+                                    {% elseif email.status.isSkipped %}
                                         <span class="badge bg-warning text-dark">{{ email.status }}</span>
-                                    {% else %}
+                                    {% elseif email.status.isSent %}
                                         <span class="badge bg-success">{{ email.status }}</span>
+                                    {% else %}
+                                        <span class="badge bg-secondary">{{ email.status }}</span>
                                     {% endif %}
                                 </td>
                             </tr>

--- a/tests/ValueObject/EmailStatusTest.php
+++ b/tests/ValueObject/EmailStatusTest.php
@@ -190,5 +190,24 @@ class EmailStatusTest extends TestCase
         $this->assertFalse($customStatus->isAlreadyProcessed());
         $this->assertFalse($customStatus->isDuplicate());
         $this->assertFalse($customStatus->isExcludedFromSurvey());
+        $this->assertFalse($customStatus->isSkipped());
+    }
+
+    public function testIsSkippedMethodDetectsAllSkipScenarios(): void
+    {
+        $alreadyProcessed = EmailStatus::alreadyProcessed(new \DateTime());
+        $duplicate = EmailStatus::duplicateInCsv();
+        $excluded = EmailStatus::excludedFromSurvey();
+        $sent = EmailStatus::sent();
+        $error = EmailStatus::error('Test error');
+        
+        // Übersprungene Status sollten true zurückgeben
+        $this->assertTrue($alreadyProcessed->isSkipped());
+        $this->assertTrue($duplicate->isSkipped());
+        $this->assertTrue($excluded->isSkipped());
+        
+        // Nicht übersprungene Status sollten false zurückgeben
+        $this->assertFalse($sent->isSkipped());
+        $this->assertFalse($error->isSkipped());
     }
 }


### PR DESCRIPTION
Introduce the EmailSkippedEvent to handle scenarios where emails are skipped during processing. Enhance the EmailStatus class with an isSkipped method to identify all skip conditions, and update tests accordingly.