### PR TITLE
Refactor ticket workflow to use TicketData value object

### DIFF
--- a/src/Service/CsvProcessor.php
+++ b/src/Service/CsvProcessor.php
@@ -13,7 +13,7 @@ namespace App\Service;
 
 use App\Entity\CsvFieldConfig;
 use App\Repository\UserRepository;
-use App\ValueObject\TicketName;
+use App\ValueObject\TicketData;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -132,26 +132,21 @@ class CsvProcessor
     }
     
     /**
-     * Erstellt ein Ticket-Array aus einer CSV-Zeile
-     * 
+     * Erstellt ein TicketData-Objekt aus einer CSV-Zeile
+     *
      * @param array $row Die CSV-Zeile
      * @param array $columnIndices Die Indizes der benötigten Spalten
      * @param array $fieldMapping Die Zuordnung der logischen zu physischen Feldnamen
-     * @return array Das Ticket als assoziatives Array
      */
-    private function createTicketFromRow(array $row, array $columnIndices, array $fieldMapping): array
+    private function createTicketFromRow(array $row, array $columnIndices, array $fieldMapping): TicketData
     {
-        $ticketNameRaw = $row[$columnIndices[$fieldMapping['ticketName']]] ?? '';
-        $ticketName = null;
-        if (trim($ticketNameRaw) !== '') {
-            $ticketName = TicketName::fromString($ticketNameRaw)->getValue();
-        }
+        $ticketNameRaw = $row[$columnIndices[$fieldMapping['ticketName']]] ?? null;
 
-        return [
-            'ticketId' => $row[$columnIndices[$fieldMapping['ticketId']]],
-            'username' => $row[$columnIndices[$fieldMapping['username']]],
-            'ticketName' => $ticketName,
-        ];
+        return TicketData::fromStrings(
+            $row[$columnIndices[$fieldMapping['ticketId']]],
+            $row[$columnIndices[$fieldMapping['username']]],
+            $ticketNameRaw
+        );
     }
     
     /**

--- a/src/ValueObject/TicketData.php
+++ b/src/ValueObject/TicketData.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\ValueObject;
+
+/**
+ * Aggregates ticket related data as value object.
+ */
+final readonly class TicketData
+{
+    public function __construct(
+        public TicketId $ticketId,
+        public Username $username,
+        public ?TicketName $ticketName = null
+    ) {
+    }
+
+    /**
+     * Convenience factory from raw strings.
+     */
+    public static function fromStrings(string $ticketId, string $username, ?string $ticketName = null): self
+    {
+        return new self(
+            TicketId::fromString($ticketId),
+            Username::fromString($username),
+            $ticketName !== null && trim($ticketName) !== '' ? TicketName::fromString($ticketName) : null
+        );
+    }
+}

--- a/tests/Service/CsvProcessorSimpleTest.php
+++ b/tests/Service/CsvProcessorSimpleTest.php
@@ -3,6 +3,7 @@ namespace App\Tests\Service;
 
 use PHPUnit\Framework\TestCase;
 use App\Service\CsvProcessor;
+use App\ValueObject\TicketData;
 
 class CsvProcessorSimpleTest extends TestCase
 {
@@ -22,9 +23,10 @@ class CsvProcessorSimpleTest extends TestCase
         // Nutze Reflection, um die private Methode zu testen
         $method = new \ReflectionMethod($processor, 'createTicketFromRow');
         $method->setAccessible(true);
+        /** @var TicketData $result */
         $result = $method->invoke($processor, $row, $columnIndices, $fieldMapping);
 
-        $this->assertEquals(50, mb_strlen($result['ticketName']));
-        $this->assertEquals(substr(str_repeat('X', 60), 0, 50), $result['ticketName']);
+        $this->assertEquals(50, mb_strlen((string) $result->ticketName));
+        $this->assertEquals(substr(str_repeat('X', 60), 0, 50), (string) $result->ticketName);
     }
 }

--- a/tests/Service/CsvProcessorTest.php
+++ b/tests/Service/CsvProcessorTest.php
@@ -6,6 +6,7 @@ use App\Service\CsvFileReader;
 use App\Repository\UserRepository;
 use App\Entity\CsvFieldConfig;
 use PHPUnit\Framework\TestCase;
+use App\ValueObject\TicketData;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -163,9 +164,9 @@ class CsvProcessorTest extends TestCase
         $cfg->method('getFieldMapping')->willReturn(['ticketId'=>'ticketId','username'=>'username','ticketName'=>'ticketName']);
         $processor = new CsvProcessor($reader, $userRepository, $requestStack);
         $res = $processor->process($uploaded, $cfg);
-        $ticketIds = array_column($res['validTickets'], 'ticketId');
-    $this->assertContainsEquals('1', $ticketIds);
-    $this->assertContainsEquals('2', $ticketIds);
+        $ticketIds = array_map(fn(TicketData $t) => (string) $t->ticketId, $res['validTickets']);
+        $this->assertContainsEquals('1', $ticketIds);
+        $this->assertContainsEquals('2', $ticketIds);
         @unlink($tmp);
     }
 }

--- a/tests/Service/CsvUploadOrchestratorTest.php
+++ b/tests/Service/CsvUploadOrchestratorTest.php
@@ -12,6 +12,7 @@ use App\Service\UnknownUsersResult;
 use App\Entity\CsvFieldConfig;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use PHPUnit\Framework\TestCase;
+use App\ValueObject\TicketData;
 
 class CsvUploadOrchestratorTest extends TestCase
 {
@@ -44,7 +45,7 @@ class CsvUploadOrchestratorTest extends TestCase
         $processingResult = [
             'unknownUsers' => ['user1', 'user2', 'user3'],
             'validTickets' => [
-                ['ticketId' => 'T-001', 'username' => 'known_user']
+                TicketData::fromStrings('T-001', 'known_user')
             ]
         ];
 
@@ -78,8 +79,8 @@ class CsvUploadOrchestratorTest extends TestCase
         $processingResult = [
             'unknownUsers' => [],
             'validTickets' => [
-                ['ticketId' => 'T-001', 'username' => 'known_user1'],
-                ['ticketId' => 'T-002', 'username' => 'known_user2']
+                TicketData::fromStrings('T-001', 'known_user1'),
+                TicketData::fromStrings('T-002', 'known_user2')
             ]
         ];
 

--- a/tests/Service/SessionManagerTest.php
+++ b/tests/Service/SessionManagerTest.php
@@ -6,6 +6,7 @@ use App\Service\SessionManager;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use PHPUnit\Framework\TestCase;
+use App\ValueObject\TicketData;
 
 /**
  * Test-Klasse für den SessionManager
@@ -40,8 +41,8 @@ class SessionManagerTest extends TestCase
         $processingResult = [
             'unknownUsers' => ['user1', 'user2', 'user3'],
             'validTickets' => [
-                ['ticketId' => 'T-001', 'username' => 'john', 'ticketName' => 'Issue 1'],
-                ['ticketId' => 'T-002', 'username' => 'jane', 'ticketName' => 'Issue 2']
+                TicketData::fromStrings('T-001', 'john', 'Issue 1'),
+                TicketData::fromStrings('T-002', 'jane', 'Issue 2')
             ]
         ];
 
@@ -124,8 +125,8 @@ class SessionManagerTest extends TestCase
     public function testGetValidTicketsReturnsStoredData(): void
     {
         $expectedTickets = [
-            ['ticketId' => 'T-001', 'username' => 'john', 'ticketName' => 'Test Issue'],
-            ['ticketId' => 'T-002', 'username' => 'jane', 'ticketName' => 'Another Issue']
+            TicketData::fromStrings('T-001', 'john', 'Test Issue'),
+            TicketData::fromStrings('T-002', 'jane', 'Another Issue')
         ];
 
         $this->session->expects($this->once())
@@ -172,7 +173,7 @@ class SessionManagerTest extends TestCase
         // Test that the same keys are used in store and get operations
         $processingResult = [
             'unknownUsers' => ['test_user'],
-            'validTickets' => [['ticketId' => 'T-123']]
+            'validTickets' => [TicketData::fromStrings('T-123', 'user')]
         ];
 
         // Store data
@@ -188,7 +189,7 @@ class SessionManagerTest extends TestCase
                     return ['test_user'];
                 }
                 if ($key === 'valid_tickets') {
-                    return [['ticketId' => 'T-123']];
+                    return [TicketData::fromStrings('T-123', 'user')];
                 }
                 return $default;
             });
@@ -197,7 +198,7 @@ class SessionManagerTest extends TestCase
         $validTickets = $this->sessionManager->getValidTickets();
 
         $this->assertEquals(['test_user'], $unknownUsers);
-        $this->assertEquals([['ticketId' => 'T-123']], $validTickets);
+        $this->assertEquals([TicketData::fromStrings('T-123', 'user')], $validTickets);
     }
 
     public function testMultipleStoreOperationsOverwritePreviousData(): void
@@ -205,7 +206,7 @@ class SessionManagerTest extends TestCase
         // First store operation
         $firstResult = [
             'unknownUsers' => ['user1'],
-            'validTickets' => [['ticketId' => 'T-001']]
+            'validTickets' => [TicketData::fromStrings('T-001', 'user1')]
         ];
 
         $this->session->expects($this->exactly(4))
@@ -217,8 +218,8 @@ class SessionManagerTest extends TestCase
         $secondResult = [
             'unknownUsers' => ['user2', 'user3'],
             'validTickets' => [
-                ['ticketId' => 'T-002'],
-                ['ticketId' => 'T-003']
+                TicketData::fromStrings('T-002', 'user2'),
+                TicketData::fromStrings('T-003', 'user3')
             ]
         ];
 
@@ -231,7 +232,7 @@ class SessionManagerTest extends TestCase
         $processingResult = [
             'unknownUsers' => ['unknown1', 'unknown2'],
             'validTickets' => [
-                ['ticketId' => 'T-100', 'username' => 'known_user', 'ticketName' => 'Valid Ticket']
+                TicketData::fromStrings('T-100', 'known_user', 'Valid Ticket')
             ]
         ];
 
@@ -248,7 +249,7 @@ class SessionManagerTest extends TestCase
                     return ['unknown1', 'unknown2'];
                 }
                 if ($key === 'valid_tickets') {
-                    return [['ticketId' => 'T-100', 'username' => 'known_user', 'ticketName' => 'Valid Ticket']];
+                    return [TicketData::fromStrings('T-100', 'known_user', 'Valid Ticket')];
                 }
                 return $default;
             });
@@ -258,7 +259,7 @@ class SessionManagerTest extends TestCase
         $unknownUsersAgain = $this->sessionManager->getUnknownUsers();
 
         $this->assertEquals(['unknown1', 'unknown2'], $unknownUsers);
-        $this->assertEquals([['ticketId' => 'T-100', 'username' => 'known_user', 'ticketName' => 'Valid Ticket']], $validTickets);
+        $this->assertEquals([TicketData::fromStrings('T-100', 'known_user', 'Valid Ticket')], $validTickets);
         $this->assertEquals(['unknown1', 'unknown2'], $unknownUsersAgain);
 
         $this->sessionManager->clearUploadData();


### PR DESCRIPTION
## Summary
- add TicketData value object bundling TicketId, Username and TicketName
- return TicketData from CsvProcessor and update EmailService to consume it
- migrate tests to use TicketData

## Testing
- `./run_all_tests.sh` *(fails: Datenbankverbindung fehlgeschlagen)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c03f9dd39c83318b2112f61ebfc8aa