### PR TITLE
Refactor EmailService for maintainability: extract EmailConfig DTO and decompose god method

### DIFF
--- a/src/Dto/EmailConfig.php
+++ b/src/Dto/EmailConfig.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Dto;
+
+use App\ValueObject\EmailAddress;
+
+/**
+ * Typisiertes DTO für die E-Mail-Versandkonfiguration.
+ *
+ * Ersetzt das vorherige untypisierte assoziative Array und macht
+ * die Konfiguration explizit, IDE-unterstützt und validiert.
+ */
+final readonly class EmailConfig
+{
+    public function __construct(
+        public string $subject,
+        public string $ticketBaseUrl,
+        public EmailAddress|string $senderEmail,
+        public string $senderName,
+        public EmailAddress|string $testEmail,
+        public bool $useCustomSMTP,
+        public ?string $smtpDSN = null,
+    ) {
+    }
+}


### PR DESCRIPTION
- Add EmailConfig DTO to replace untyped associative array for email configuration
- Extract processSingleTicket() to handle per-ticket logic with clear skip conditions
- Extract persistEmailRecord() with error fallback to eliminate duplicated try/catch
- Extract createAndDispatchSkippedRecord() to consolidate skip record creation + event dispatch
- Extract normalizeTicket(), loadExistingTickets(), resolveTemplateContent(), flushRemaining()
- Replace verbose property declarations with typed property syntax
- Reduce sendTicketEmailsWithDuplicateCheck() from 197 lines to a clean 37-line loop
- Update tests to use EmailConfig DTO instead of raw arrays

https://claude.ai/code/session_017iH8BdkpeYquLHNWrfvzVV